### PR TITLE
Fix name tags of some SG ingress rules

### DIFF
--- a/obp_private_alb_basic/private-load-balancer.tf
+++ b/obp_private_alb_basic/private-load-balancer.tf
@@ -39,7 +39,7 @@ resource "aws_vpc_security_group_ingress_rule" "alb_allow_http_all" {
   cidr_ipv4         = "0.0.0.0/0"
 
   tags = {
-    Name = "private_alb_allow_https_all"
+    Name = "private_alb_allow_http_all"
   }
 }
 
@@ -56,7 +56,6 @@ resource "aws_vpc_security_group_ingress_rule" "alb_allow_https_all" {
   }
 }
 
-
 resource "aws_vpc_security_group_ingress_rule" "alb_allow_lb_internal" {
   security_group_id = aws_security_group.alb.id
   description       = "Allow 6000 for private lb"
@@ -65,7 +64,7 @@ resource "aws_vpc_security_group_ingress_rule" "alb_allow_lb_internal" {
   ip_protocol       = "tcp"
   cidr_ipv4         = var.vpc_cidr_block
   tags = {
-    Name = "private_alb_allow_https_epfl"
+    Name = "private_alb_allow_6000_vpc_internal"
   }
 }
 
@@ -80,4 +79,3 @@ resource "aws_vpc_security_group_egress_rule" "alb_allow_everything_outgoing" {
     Name = "private_alb_allow_everything_outgoing"
   }
 }
-


### PR DESCRIPTION
Not important at all, but I was grep'ing by "EPFL" string and I saw these two that are clearly not correct
