### PR TITLE
Retain aws-waf-logs for 30 days instead of 7

### DIFF
--- a/obp_private_alb_config/private-alb-waf.tf
+++ b/obp_private_alb_config/private-alb-waf.tf
@@ -276,7 +276,7 @@ resource "aws_wafv2_web_acl_association" "waf_association" {
 #tfsec:ignore:aws-cloudwatch-log-group-customer-key
 resource "aws_cloudwatch_log_group" "waf_logs" {
   name              = "aws-waf-logs-private-loadbalancer"
-  retention_in_days = 7
+  retention_in_days = 30
   tags_all = {
     Name = "aws-waf-logs-private-loadbalancer"
   }


### PR DESCRIPTION
Made sure that 30 is one of the Blessed Values: https://registry.terraform.io/providers/hashicorp/aws/2.70.1/docs/resources/cloudwatch_log_group#retention_in_days-1