### PR TITLE
Revert "Enable EC2MetaDataSSRF_QUERYARGUMENTS WAF rule"

### DIFF
--- a/obp_private_alb_config/private-alb-waf.tf
+++ b/obp_private_alb_config/private-alb-waf.tf
@@ -62,6 +62,15 @@ resource "aws_wafv2_web_acl" "basic_protection" {
           name = "SizeRestrictions_BODY"
         }
         rule_action_override {
+          # Ignore SSRF Query Arguments - we'll deal with those in a later rule
+          # staging 2025-03-24: doesn't seem to get hit
+          action_to_use {
+            count {}
+          }
+
+          name = "EC2MetaDataSSRF_QUERYARGUMENTS"
+        }
+        rule_action_override {
           # This messes with Keycloak, it's unclear whether it's for dev setups only.
           # Once openbluebrain is publicly accessible, evaluate whether we need to add an exception
           # staging 2025-03-24: doesn't seem to get hit


### PR DESCRIPTION
This reverts commit 7e1cc13c4ac2fb1bf21a3fba5021cf6fe00ecf43.

Users are experiencing some 403 that might come from the WAF. Let's revert and try again.