### PR TITLE
Waf allow internal traffic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -236,6 +236,7 @@ module "private_alb_config" {
 
   private_alb_arn      = module.private_alb_basic.private_alb_arn
   waf_logs_bucket_name = var.waf_logs_bucket_name
+  vpc_cidr_block       = module.network.vpc_cidr_block
 }
 
 module "public_nlb_config" {

--- a/obp_private_alb_config/private-alb-waf.tf
+++ b/obp_private_alb_config/private-alb-waf.tf
@@ -1,5 +1,5 @@
 resource "aws_wafv2_ip_set" "internal_ips" {
-  name               = "internal IPs"
+  name               = "internal_IPs"
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
   addresses          = ["10.0.0.0/16"]

--- a/obp_private_alb_config/private-alb-waf.tf
+++ b/obp_private_alb_config/private-alb-waf.tf
@@ -1,3 +1,9 @@
+resource "aws_wafv2_ip_set" "internal_ips" {
+  name               = "internal IPs"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = ["10.0.0.0/16"]
+}
 resource "aws_wafv2_web_acl" "basic_protection" {
   name  = "private-alb-waf"
   scope = "REGIONAL"
@@ -34,6 +40,27 @@ resource "aws_wafv2_web_acl" "basic_protection" {
     visibility_config {
       cloudwatch_metrics_enabled = false
       metric_name                = "obi-country-blocklist"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name     = "obi-allow-internal-traffic"
+    priority = 5
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.internal_ips.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "obi_allow-internal-traffic"
       sampled_requests_enabled   = false
     }
   }

--- a/obp_private_alb_config/private-alb-waf.tf
+++ b/obp_private_alb_config/private-alb-waf.tf
@@ -2,7 +2,7 @@ resource "aws_wafv2_ip_set" "internal_ips" {
   name               = "internal_IPs"
   scope              = "REGIONAL"
   ip_address_version = "IPV4"
-  addresses          = ["10.0.0.0/16"]
+  addresses          = [var.vpc_cidr_block]
 }
 resource "aws_wafv2_web_acl" "basic_protection" {
   name  = "private-alb-waf"

--- a/obp_private_alb_config/variables.tf
+++ b/obp_private_alb_config/variables.tf
@@ -9,3 +9,9 @@ variable "waf_logs_bucket_name" {
   type        = string
   sensitive   = false
 }
+
+variable "vpc_cidr_block" {
+  description = "CIDR block or network range of the VPC"
+  type        = string
+  sensitive   = false
+}


### PR DESCRIPTION
This should explicitly allow internal traffic through the WAF. To be monitored and see if we need to allow additional IPs.