### PR TITLE
Fix WAF issue that effectively disabled the GenericLFI rule

### DIFF
--- a/obp_private_alb_config/private-alb-waf.tf
+++ b/obp_private_alb_config/private-alb-waf.tf
@@ -215,19 +215,23 @@ resource "aws_wafv2_web_acl" "basic_protection" {
         statement {
           label_match_statement {
             scope = "LABEL"
-            key   = "awswaf:managed:aws:core-rule-set:GenericLFI_BODY"
+            key   = "awswaf:managed:aws:core-rule-set:GenericLFI_Body"
           }
         }
 
         statement {
-          regex_match_statement {
-            field_to_match {
-              uri_path {}
-            }
-            regex_string = "^/api/entitycore/.*/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/assets$"
-            text_transformation {
-              priority = 0
-              type     = "NONE"
+          not_statement {
+            statement {
+              regex_match_statement {
+                field_to_match {
+                  uri_path {}
+                }
+                regex_string = "^/api/entitycore/.*/[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}/assets$"
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
The previous change allowed every request matching the GenericLFI rule through the firewall, none of them would have hit our exception.

This PR fixes that by fixing the match condition to trigger our exception rule, and by blocking everything _except_ the allowed URI (instead of the inverse - that's a bug that was not spotted due to the previous bug).