### PR TITLE
Update ip range of azure staging in private nlb, so that azure staging in south central us can reach staging.openbraininstitute.org lb via the vpn

### DIFF
--- a/private_nlb/nlb.tf
+++ b/private_nlb/nlb.tf
@@ -71,7 +71,7 @@ resource "aws_vpc_security_group_ingress_rule" "nlb_allow_https_azure_staging" {
   from_port         = 443
   to_port           = 443
   ip_protocol       = "tcp"
-  cidr_ipv4         = "10.101.0.0/16"
+  cidr_ipv4         = "10.102.0.0/16"
 
   tags = {
     Name = "private_nlb_allow_https_within_vpc"


### PR DESCRIPTION
https://github.com/openbraininstitute/INFRA/issues/364
