### PR TITLE
Fix the redirects for the other alternative hostnames: should point to the public main hostname which is now in azure

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ module "private_alb_basic" {
   vpc_id                        = module.network.vpc_id
   vpc_cidr_block                = module.network.vpc_cidr_block
   lb_access_logs_bucket         = module.s3.lb_access_logs_bucket
-  main_domain_hostname          = var.cell_a_openbraininstitute_org_domain_name
+  main_domain_hostname          = var.primary_domain_name                       # used for the redirects of other hostnames like openbluebrain.com => needs to remain the public main hostname
   main_domain_hostname_cert_arn = module.openbluebrain_com_cert.certificate_arn # It doesn't matter which one we take as default as we're adding all them anyway as additional certificates.
 
   redirected_hostnames = [

--- a/obp_private_alb_basic/private-alb-https-listener-with-default.tf
+++ b/obp_private_alb_basic/private-alb-https-listener-with-default.tf
@@ -26,7 +26,7 @@ resource "aws_lb_listener_certificate" "certs_for_alb" {
 
 # Generates a separate rule for each of the hostnames in redirect_hostnames
 # => each individual rule remains below the 5 conditions limit
-resource "aws_lb_listener_rule" "private_keycloak_redirect" {
+resource "aws_lb_listener_rule" "redirect_alternative_hostname" {
   # Generates a set [0, 1, 2, ..] with an index for each entry in var.redirected_hostnames
   for_each = toset(formatlist("%s", range(length(var.redirected_hostnames))))
 


### PR DESCRIPTION
https://github.com/openbraininstitute/INFRA/issues/373
