### PR TITLE
Delete duplicated default security group resource

### DIFF
--- a/network/vpc.tf
+++ b/network/vpc.tf
@@ -11,19 +11,3 @@ resource "aws_vpc" "main_vpc" {
   }
 }
 
-# Default security group under Terraform management (e.g., for tagging)
-resource "aws_default_security_group" "default" {
-  vpc_id = aws_vpc.main_vpc.id
-  ingress {
-    protocol  = -1
-    self      = true
-    from_port = 0
-    to_port   = 0
-  }
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}


### PR DESCRIPTION
VPC 'default' security group is managed in the deployment repo: https://github.com/openbraininstitute/aws-terraform-deployment/commit/abc93b4b9538a17c3bc539aa2db3cc71423d042f