### PR TITLE
Set Terraform AWS Provider to v6

### DIFF
--- a/site_to_site_vpn/provider.tf
+++ b/site_to_site_vpn/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.24.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/terraform-config.tf
+++ b/terraform-config.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.24"
+      version = "~> 6.0"
     }
   }
 


### PR DESCRIPTION
This repo was already using v6. Setting it to `6.0` is only for consistency with the other changes I am making

https://github.com/openbraininstitute/INFRA/issues/505