### PR TITLE
Export the ARN of the public NLB, so a listener at UDP 8443 can be attached in the aws-terraform-deployment repo

### DIFF
--- a/obp_public_nlb_basic/public-network-load-balancer.tf
+++ b/obp_public_nlb_basic/public-network-load-balancer.tf
@@ -74,6 +74,19 @@ resource "aws_vpc_security_group_ingress_rule" "nlb_allow_https_all" {
   }
 }
 
+# For https://github.com/openbraininstitute/INFRA/issues/558
+resource "aws_vpc_security_group_ingress_rule" "nlb_allow_8443_udp_all" {
+  security_group_id = aws_security_group.nlb.id
+  description       = "Allow UDP 8443"
+  from_port         = 8443
+  to_port           = 8443
+  ip_protocol       = "udp"
+  cidr_ipv4         = "0.0.0.0/0"
+
+  tags = {
+    Name = "public_nlb_allow_8443_udp_all"
+  }
+}
 
 resource "aws_vpc_security_group_ingress_rule" "nlb_allow_lb_internal" {
   security_group_id = aws_security_group.nlb.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,6 +78,11 @@ output "generic_private_alb_security_group_id" {
   value       = module.private_alb_basic.alb_securitygroup_id
 }
 
+output "public_nlb_arn" {
+  description = "The ARN of the public NLB"
+  value       = module.public_nlb_basic.public_nlb_arn
+}
+
 output "virtual_lab_manager_secrets_arn" {
   description = "ARN of the Virtual La  secrets manager service"
   value       = aws_secretsmanager_secret.virtual_lab_manager_secrets.arn


### PR DESCRIPTION
https://github.com/openbraininstitute/INFRA/issues/558
